### PR TITLE
Vendor multibase

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -53,7 +53,6 @@
     "microblogging",
     "Misskey",
     "msvc",
-    "multibase",
     "multicodec",
     "multikey",
     "multitenancy",

--- a/deno.json
+++ b/deno.json
@@ -7,6 +7,7 @@
   ],
   "imports": {
     "@logtape/logtape": "jsr:@logtape/logtape@^0.8.2",
+    "@multiformats/base-x": "npm:@multiformats/base-x@^4.0.1",
     "@std/fs": "jsr:@std/fs@^1.0.3",
     "@std/path": "jsr:@std/path@^1.0.6",
     "@std/semver": "jsr:@std/semver@^1.0.3",

--- a/examples/express/package-lock.json
+++ b/examples/express/package-lock.json
@@ -505,7 +505,6 @@
         "asn1js": "^3.0.5",
         "json-canon": "^1.0.1",
         "jsonld": "^8.3.2",
-        "multibase": "^4.0.6",
         "multicodec": "^3.2.1",
         "pkijs": "^3.2.4",
         "uri-template-router": "^0.0.16",
@@ -1424,20 +1423,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "license": "MIT",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
     },
     "node_modules/multicodec": {
       "version": "3.2.1",

--- a/examples/next-app-router/package-lock.json
+++ b/examples/next-app-router/package-lock.json
@@ -196,7 +196,6 @@
         "asn1js": "^3.0.5",
         "json-canon": "^1.0.1",
         "jsonld": "^8.3.2",
-        "multibase": "^4.0.6",
         "multicodec": "^3.2.1",
         "pkijs": "^3.2.4",
         "uri-template-router": "^0.0.16",
@@ -4231,20 +4230,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "license": "MIT",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
     },
     "node_modules/multicodec": {
       "version": "3.2.1",

--- a/src/codegen/__snapshots__/class.test.ts.snap
+++ b/src/codegen/__snapshots__/class.test.ts.snap
@@ -10,7 +10,7 @@ import { type Span, SpanStatusCode, type TracerProvider, trace }
 import { LanguageTag, parseLanguageTag }
     from \\"@phensley/language-tag\\";
 import { decode as decodeMultibase, encode as encodeMultibase }
-    from \\"multibase\\";import { type DocumentLoader, getDocumentLoader, type RemoteDocument }
+    from \\"../multibase/index.ts\\";import { type DocumentLoader, getDocumentLoader, type RemoteDocument }
     from \\"../runtime/docloader.ts\\";
 import {
     exportSpki,

--- a/src/codegen/class.ts
+++ b/src/codegen/class.ts
@@ -112,7 +112,7 @@ export async function* generateClasses(
   yield `import { LanguageTag, parseLanguageTag }
     from "@phensley/language-tag";\n`;
   yield `import { decode as decodeMultibase, encode as encodeMultibase }
-    from "multibase";`;
+    from "../multibase/index.ts";`;
   yield `import { type DocumentLoader, getDocumentLoader, type RemoteDocument }
     from "${runtimePath}/docloader.ts";\n`;
   yield `import {

--- a/src/deno.json
+++ b/src/deno.json
@@ -40,7 +40,6 @@
     "json-canon": "npm:json-canon@^1.0.1",
     "jsonld": "npm:jsonld@^8.3.2",
     "mock_fetch": "jsr:@hongminhee/deno-mock-fetch@^0.3.2",
-    "multibase": "npm:multibase@^4.0.6",
     "multicodec": "npm:multicodec@^3.2.1",
     "pkijs": "npm:pkijs@^3.2.4",
     "uri-template-router": "npm:uri-template-router@^0.0.16",

--- a/src/multibase/base.ts
+++ b/src/multibase/base.ts
@@ -1,0 +1,34 @@
+import { encodeText } from "./util.ts";
+import type { BaseCode, BaseName, Codec, CodecFactory } from "./types.d.ts";
+
+/**
+ * Class to encode/decode in the supported Bases
+ */
+export class Base {
+  public codeBuf: Uint8Array;
+  codec: Codec;
+
+  constructor(
+    public name: BaseName,
+    private code: BaseCode,
+    factory: CodecFactory,
+    private alphabet: string,
+  ) {
+    this.codeBuf = encodeText(this.code);
+    this.alphabet = alphabet;
+    this.codec = factory(alphabet);
+  }
+
+  encode(buf: Uint8Array): string {
+    return this.codec.encode(buf);
+  }
+
+  decode(string: string): Uint8Array {
+    for (const char of string) {
+      if (this.alphabet && this.alphabet.indexOf(char) < 0) {
+        throw new Error(`invalid character '${char}' in '${string}'`);
+      }
+    }
+    return this.codec.decode(string);
+  }
+}

--- a/src/multibase/constants.ts
+++ b/src/multibase/constants.ts
@@ -1,0 +1,89 @@
+import baseX from "@multiformats/base-x";
+import { Base } from "./base.ts";
+import { rfc4648 } from "./rfc4648.ts";
+import { decodeText, encodeText } from "./util.ts";
+import type { BaseCode, BaseName, CodecFactory } from "./types.d.ts";
+
+const identity: CodecFactory = () => {
+  return {
+    encode: decodeText,
+    decode: encodeText,
+  };
+};
+
+/**
+ * name, code, implementation, alphabet
+ *
+ * @type {Array<[BaseName, BaseCode, CodecFactory, string]>}
+ */
+const constants: Array<[BaseName, BaseCode, CodecFactory, string]> = [
+  ["identity", "\x00", identity, ""],
+  ["base2", "0", rfc4648(1), "01"],
+  ["base8", "7", rfc4648(3), "01234567"],
+  ["base10", "9", baseX, "0123456789"],
+  ["base16", "f", rfc4648(4), "0123456789abcdef"],
+  ["base16upper", "F", rfc4648(4), "0123456789ABCDEF"],
+  ["base32hex", "v", rfc4648(5), "0123456789abcdefghijklmnopqrstuv"],
+  ["base32hexupper", "V", rfc4648(5), "0123456789ABCDEFGHIJKLMNOPQRSTUV"],
+  ["base32hexpad", "t", rfc4648(5), "0123456789abcdefghijklmnopqrstuv="],
+  ["base32hexpadupper", "T", rfc4648(5), "0123456789ABCDEFGHIJKLMNOPQRSTUV="],
+  ["base32", "b", rfc4648(5), "abcdefghijklmnopqrstuvwxyz234567"],
+  ["base32upper", "B", rfc4648(5), "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"],
+  ["base32pad", "c", rfc4648(5), "abcdefghijklmnopqrstuvwxyz234567="],
+  ["base32padupper", "C", rfc4648(5), "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567="],
+  ["base32z", "h", rfc4648(5), "ybndrfg8ejkmcpqxot1uwisza345h769"],
+  ["base36", "k", baseX, "0123456789abcdefghijklmnopqrstuvwxyz"],
+  ["base36upper", "K", baseX, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"],
+  [
+    "base58btc",
+    "z",
+    baseX,
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz",
+  ],
+  [
+    "base58flickr",
+    "Z",
+    baseX,
+    "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ",
+  ],
+  [
+    "base64",
+    "m",
+    rfc4648(6),
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+  ],
+  [
+    "base64pad",
+    "M",
+    rfc4648(6),
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+  ],
+  [
+    "base64url",
+    "u",
+    rfc4648(6),
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+  ],
+  [
+    "base64urlpad",
+    "U",
+    rfc4648(6),
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=",
+  ],
+];
+
+export const names = constants.reduce<Record<BaseName, Base>>(
+  (prev, tupple) => {
+    prev[tupple[0]] = new Base(tupple[0], tupple[1], tupple[2], tupple[3]);
+    return prev;
+  },
+  {} as Record<BaseName, Base>,
+);
+
+export const codes = constants.reduce<Record<BaseCode, Base>>(
+  (prev, tupple) => {
+    prev[tupple[1]] = names[tupple[0]];
+    return prev;
+  },
+  {} as Record<BaseCode, Base>,
+);

--- a/src/multibase/index.ts
+++ b/src/multibase/index.ts
@@ -1,0 +1,82 @@
+import * as constants from "./constants.ts";
+import { concat, decodeText, encodeText } from "./util.ts";
+import type { BaseCode, BaseName, BaseNameOrCode } from "./types.d.ts";
+import type { Base } from "./base.ts";
+
+/**
+ * Encode data with the specified base and add the multibase prefix.
+ *
+ * @throws {Error} Will throw if the encoding is not supported
+ */
+export function encode(
+  nameOrCode: BaseNameOrCode,
+  buf: Uint8Array,
+): Uint8Array {
+  const enc = encoding(nameOrCode);
+  const data = encodeText(enc.encode(buf));
+
+  return concat([enc.codeBuf, data], enc.codeBuf.length + data.length);
+}
+
+/**
+ * Takes a Uint8Array or string encoded with multibase header, decodes it and
+ * returns the decoded buffer
+ *
+ * @throws {Error} Will throw if the encoding is not supported
+ */
+export function decode(data: Uint8Array | string): Uint8Array {
+  if (data instanceof Uint8Array) {
+    data = decodeText(data);
+  }
+  const prefix = data[0];
+
+  // Make all encodings case-insensitive except the ones that include upper and lower chars in the alphabet
+  if (
+    ["f", "F", "v", "V", "t", "T", "b", "B", "c", "C", "h", "k", "K"].includes(
+      prefix,
+    )
+  ) {
+    data = data.toLowerCase();
+  }
+  const enc = encoding(data[0] as BaseCode);
+  return enc.decode(data.substring(1));
+}
+
+/**
+ * Get the encoding by name or code
+ * @throws {Error} Will throw if the encoding is not supported
+ */
+function encoding(nameOrCode: BaseNameOrCode): Base {
+  if (
+    Object.prototype.hasOwnProperty.call(
+      constants.names,
+      nameOrCode as BaseName,
+    )
+  ) {
+    return constants.names[nameOrCode as BaseName];
+  } else if (
+    Object.prototype.hasOwnProperty.call(
+      constants.codes,
+      /** @type {BaseCode} */ (nameOrCode),
+    )
+  ) {
+    return constants.codes[nameOrCode as BaseCode];
+  } else {
+    throw new Error(`Unsupported encoding: ${nameOrCode}`);
+  }
+}
+
+/**
+ * Get encoding from data
+ *
+ * @param {string|Uint8Array} data
+ * @returns {Base}
+ * @throws {Error} Will throw if the encoding is not supported
+ */
+export function encodingFromData(data: string | Uint8Array): Base {
+  if (data instanceof Uint8Array) {
+    data = decodeText(data);
+  }
+
+  return encoding(data[0] as BaseCode);
+}

--- a/src/multibase/multibase.test.ts
+++ b/src/multibase/multibase.test.ts
@@ -1,0 +1,128 @@
+import { decode, encode } from "./index.ts";
+import * as constants from "./constants.ts";
+import { decodeText, encodeText } from "./util.ts";
+import { assertEquals, assertThrows } from "@std/assert";
+import { test } from "../testing/mod.ts";
+import type { BaseName } from "./types.d.ts";
+
+test("multibase.encode and decode", () => {
+  const testCases: Array<[BaseName, string, string]> = [
+    ["base16", decodeText(Uint8Array.from([0x01])), "f01"],
+    ["base16", decodeText(Uint8Array.from([15])), "f0f"],
+    ["base16", "f", "f66"],
+    ["base16", "fo", "f666f"],
+    ["base16", "foo", "f666f6f"],
+    ["base16", "foob", "f666f6f62"],
+    ["base16", "fooba", "f666f6f6261"],
+    ["base16", "foobar", "f666f6f626172"],
+    ["base32", "yes mani !", "bpfsxgidnmfxgsibb"],
+    ["base32", "f", "bmy"],
+    ["base32", "fo", "bmzxq"],
+    ["base32", "foo", "bmzxw6"],
+    ["base32", "foob", "bmzxw6yq"],
+    ["base32", "fooba", "bmzxw6ytb"],
+    ["base32", "foobar", "bmzxw6ytboi"],
+    ["base32pad", "yes mani !", "cpfsxgidnmfxgsibb"],
+    ["base32pad", "f", "cmy======"],
+    ["base32pad", "fo", "cmzxq===="],
+    ["base32pad", "foo", "cmzxw6==="],
+    ["base32pad", "foob", "cmzxw6yq="],
+    ["base32pad", "fooba", "cmzxw6ytb"],
+    ["base32pad", "foobar", "cmzxw6ytboi======"],
+    ["base32hex", "yes mani !", "vf5in683dc5n6i811"],
+    ["base32hex", "f", "vco"],
+    ["base32hex", "fo", "vcpng"],
+    ["base32hex", "foo", "vcpnmu"],
+    ["base32hex", "foob", "vcpnmuog"],
+    ["base32hex", "fooba", "vcpnmuoj1"],
+    ["base32hex", "foobar", "vcpnmuoj1e8"],
+    ["base32hexpad", "yes mani !", "tf5in683dc5n6i811"],
+    ["base32hexpad", "f", "tco======"],
+    ["base32hexpad", "fo", "tcpng===="],
+    ["base32hexpad", "foo", "tcpnmu==="],
+    ["base32hexpad", "foob", "tcpnmuog="],
+    ["base32hexpad", "fooba", "tcpnmuoj1"],
+    ["base32hexpad", "foobar", "tcpnmuoj1e8======"],
+    ["base32z", "yes mani !", "hxf1zgedpcfzg1ebb"],
+    ["base58flickr", "yes mani !", "Z7Pznk19XTTzBtx"],
+    ["base58btc", "yes mani !", "z7paNL19xttacUY"],
+    ["base64", "÷ïÿ", "mw7fDr8O/"],
+    ["base64", "f", "mZg"],
+    ["base64", "fo", "mZm8"],
+    ["base64", "foo", "mZm9v"],
+    ["base64", "foob", "mZm9vYg"],
+    ["base64", "fooba", "mZm9vYmE"],
+    ["base64", "foobar", "mZm9vYmFy"],
+    ["base64", "÷ïÿ🥰÷ïÿ😎🥶🤯", "mw7fDr8O/8J+lsMO3w6/Dv/CfmI7wn6W28J+krw"],
+    ["base64pad", "f", "MZg=="],
+    ["base64pad", "fo", "MZm8="],
+    ["base64pad", "foo", "MZm9v"],
+    ["base64pad", "foob", "MZm9vYg=="],
+    ["base64pad", "fooba", "MZm9vYmE="],
+    ["base64pad", "foobar", "MZm9vYmFy"],
+    ["base64url", "÷ïÿ", "uw7fDr8O_"],
+    ["base64url", "÷ïÿ🥰÷ïÿ😎🥶🤯", "uw7fDr8O_8J-lsMO3w6_Dv_CfmI7wn6W28J-krw"],
+    ["base64urlpad", "f", "UZg=="],
+    ["base64urlpad", "fo", "UZm8="],
+    ["base64urlpad", "foo", "UZm9v"],
+    ["base64urlpad", "foob", "UZm9vYg=="],
+    ["base64urlpad", "fooba", "UZm9vYmE="],
+    ["base64urlpad", "foobar", "UZm9vYmFy"],
+    [
+      "base64urlpad",
+      "÷ïÿ🥰÷ïÿ😎🥶🤯",
+      "Uw7fDr8O_8J-lsMO3w6_Dv_CfmI7wn6W28J-krw==",
+    ],
+  ];
+
+  for (const [name, input, expectedOutput] of testCases) {
+    const encoded = encode(name, encodeText(input));
+    assertEquals(
+      decodeText(encoded),
+      expectedOutput,
+      `Encoding ${name} failed`,
+    );
+
+    const decoded = decode(expectedOutput);
+    assertEquals(decoded, encodeText(input), `Decoding ${name} failed`);
+
+    const decodedFromBuffer = decode(encodeText(expectedOutput));
+    assertEquals(
+      decodedFromBuffer,
+      encodeText(input),
+      `Decoding buffer of ${name} failed`,
+    );
+  }
+
+  test("should allow base32pad full alphabet", () => {
+    const encodedStr = "ctimaq4ygg2iegci7";
+    const decoded = decode(encodedStr);
+    const encoded = encode("c", decoded);
+    assertEquals(decode(encoded), decoded);
+  });
+});
+
+test("multibase.encode fails on unsupported bases", () => {
+  const unsupportedBases: Array<[BaseName, string, string]> = []; // Add your unsupported bases here if any
+
+  for (const [name, input] of unsupportedBases) {
+    assertThrows(
+      () => {
+        encode(name, encodeText(input));
+      },
+      `Encoding unsupported base ${name} should throw`,
+    );
+  }
+});
+
+test("constants", () => {
+  test("constants indexed by name", () => {
+    const names = constants.names;
+    assertEquals(Object.keys(names).length, 23);
+  });
+
+  test("constants indexed by code", () => {
+    const codes = constants.codes;
+    assertEquals(Object.keys(codes).length, 23);
+  });
+});

--- a/src/multibase/rfc4648.ts
+++ b/src/multibase/rfc4648.ts
@@ -1,0 +1,103 @@
+import type { CodecFactory } from "./types.d.ts";
+
+const decode = (
+  string: string,
+  alphabet: string,
+  bitsPerChar: number,
+): Uint8Array => {
+  // Build the character lookup table:
+  const codes: Record<string, number> = {};
+  for (let i = 0; i < alphabet.length; ++i) {
+    codes[alphabet[i]] = i;
+  }
+
+  // Count the padding bytes:
+  let end = string.length;
+  while (string[end - 1] === "=") {
+    --end;
+  }
+
+  // Allocate the output:
+  const out = new Uint8Array((end * bitsPerChar / 8) | 0);
+
+  // Parse the data:
+  let bits = 0; // Number of bits currently in the buffer
+  let buffer = 0; // Bits waiting to be written out, MSB first
+  let written = 0; // Next byte to write
+  for (let i = 0; i < end; ++i) {
+    // Read one character from the string:
+    const value = codes[string[i]];
+    if (value === undefined) {
+      throw new SyntaxError("Invalid character " + string[i]);
+    }
+
+    // Append the bits to the buffer:
+    buffer = (buffer << bitsPerChar) | value;
+    bits += bitsPerChar;
+
+    // Write out some bits if the buffer has a byte's worth:
+    if (bits >= 8) {
+      bits -= 8;
+      out[written++] = 0xff & (buffer >> bits);
+    }
+  }
+
+  // Verify that we have received just enough bits:
+  if (bits >= bitsPerChar || 0xff & (buffer << (8 - bits))) {
+    throw new SyntaxError("Unexpected end of data");
+  }
+
+  return out;
+};
+
+const encode = (
+  data: Uint8Array,
+  alphabet: string,
+  bitsPerChar: number,
+): string => {
+  const pad = alphabet[alphabet.length - 1] === "=";
+  const mask = (1 << bitsPerChar) - 1;
+  let out = "";
+
+  let bits = 0; // Number of bits currently in the buffer
+  let buffer = 0; // Bits waiting to be written out, MSB first
+  for (let i = 0; i < data.length; ++i) {
+    // Slurp data into the buffer:
+    buffer = (buffer << 8) | data[i];
+    bits += 8;
+
+    // Write out as much as we can:
+    while (bits > bitsPerChar) {
+      bits -= bitsPerChar;
+      out += alphabet[mask & (buffer >> bits)];
+    }
+  }
+
+  // Partial character:
+  if (bits) {
+    out += alphabet[mask & (buffer << (bitsPerChar - bits))];
+  }
+
+  // Add padding characters until we hit a byte boundary:
+  if (pad) {
+    while ((out.length * bitsPerChar) & 7) {
+      out += "=";
+    }
+  }
+
+  return out;
+};
+
+/**
+ * RFC4648 Factory
+ */
+export const rfc4648 = (bitsPerChar: number): CodecFactory => (alphabet) => {
+  return {
+    encode(input: Uint8Array): string {
+      return encode(input, alphabet, bitsPerChar);
+    },
+    decode(input: string): Uint8Array {
+      return decode(input, alphabet, bitsPerChar);
+    },
+  };
+};

--- a/src/multibase/types.d.ts
+++ b/src/multibase/types.d.ts
@@ -1,0 +1,61 @@
+export type BaseCode =
+  | "\x00"
+  | "0"
+  | "7"
+  | "9"
+  | "f"
+  | "F"
+  | "v"
+  | "V"
+  | "t"
+  | "T"
+  | "b"
+  | "B"
+  | "c"
+  | "C"
+  | "h"
+  | "k"
+  | "K"
+  | "z"
+  | "Z"
+  | "m"
+  | "M"
+  | "u"
+  | "U";
+
+/**
+ * - Names of the supported encodings
+ */
+export type BaseName =
+  | "identity"
+  | "base2"
+  | "base8"
+  | "base10"
+  | "base16"
+  | "base16upper"
+  | "base32hex"
+  | "base32hexupper"
+  | "base32hexpad"
+  | "base32hexpadupper"
+  | "base32"
+  | "base32upper"
+  | "base32pad"
+  | "base32padupper"
+  | "base32z"
+  | "base36"
+  | "base36upper"
+  | "base58btc"
+  | "base58flickr"
+  | "base64"
+  | "base64pad"
+  | "base64url"
+  | "base64urlpad";
+
+export type BaseNameOrCode = BaseCode | BaseName;
+export interface Codec {
+  encode: (buffer: Uint8Array) => string;
+  decode: (hash: string) => Uint8Array;
+}
+export interface CodecFactory {
+  (input: string): Codec;
+}

--- a/src/multibase/util.ts
+++ b/src/multibase/util.ts
@@ -1,5 +1,5 @@
 const textDecoder = new TextDecoder();
-export const decodeText = (bytes: ArrayBufferView | ArrayBuffer): string =>
+export const decodeText = (bytes: DataView | Uint8Array): string =>
   textDecoder.decode(bytes);
 
 const textEncoder = new TextEncoder();

--- a/src/multibase/util.ts
+++ b/src/multibase/util.ts
@@ -1,0 +1,22 @@
+const textDecoder = new TextDecoder();
+export const decodeText = (bytes: ArrayBufferView | ArrayBuffer): string =>
+  textDecoder.decode(bytes);
+
+const textEncoder = new TextEncoder();
+export const encodeText = (text: string): Uint8Array =>
+  textEncoder.encode(text);
+
+export function concat(
+  arrs: Array<ArrayLike<number>>,
+  length: number,
+): Uint8Array {
+  const output = new Uint8Array(length);
+  let offset = 0;
+
+  for (const arr of arrs) {
+    output.set(arr, offset);
+    offset += arr.length;
+  }
+
+  return output;
+}

--- a/src/runtime/key.ts
+++ b/src/runtime/key.ts
@@ -3,7 +3,7 @@ import { decodeBase64, encodeBase64 } from "@std/encoding/base64";
 import { decodeBase64Url } from "@std/encoding/base64url";
 import { decodeHex } from "@std/encoding/hex";
 import { Integer, Sequence } from "asn1js";
-import { decode, encode } from "multibase";
+import { decode, encode } from "../multibase/index.ts";
 import { addPrefix, getCodeFromData, rmPrefix } from "multicodec";
 import { createPublicKey } from "node:crypto";
 import { PublicKeyInfo } from "pkijs";

--- a/src/sig/proof.test.ts
+++ b/src/sig/proof.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertInstanceOf, assertRejects } from "@std/assert";
 import { decodeHex, encodeHex } from "@std/encoding/hex";
-import { decode } from "multibase";
+import { decode } from "../multibase/index.ts";
 import { importMultibaseKey } from "../runtime/key.ts";
 import { mockDocumentLoader } from "../testing/docloader.ts";
 import {

--- a/src/vocab/vocab.test.ts
+++ b/src/vocab/vocab.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@std/assert";
 import { assertSnapshot } from "@std/testing/snapshot";
 import { toPascalCase } from "@std/text/to-pascal-case";
-import { decode } from "multibase";
+import { decode } from "../multibase/index.ts";
 import {
   loadSchemaFiles,
   type PropertySchema,


### PR DESCRIPTION
Vendors multibase into the fedify repository. Care was taken to migrate types faithfully into Typescript, and relevant tests 1-to-1 into @std/testing, functionality-wise. I am not very experienced in @std/testing so I expect some pushback, but keep in mind that the tests test what they did in the multibase repo.

Unused functions were removed, as well as their tests, as there's no guarantee they'd be used in the future. If the need arises, they're easy to vendor.

Given that multibase uses MIT license, and fedify as well, there should be no issue there (not legal advice 😅)